### PR TITLE
fix(getgovernance): expose rule text for scheduled proposals

### DIFF
--- a/commands/getgovernance.py
+++ b/commands/getgovernance.py
@@ -80,12 +80,22 @@ def execute(raw_command: str, container):
         for activation_height, uid in chain_state._lifecycle_manager.scheduled_updates:
             uid_hex = _normalize_hexish(uid)
             lifecycle[uid_hex] = "approved-and-scheduled"
-            scheduled_updates.append(
-                {
-                    "activation_height": int(activation_height),
-                    "update_id": uid_hex,
-                }
-            )
+            entry = {
+                "activation_height": int(activation_height),
+                "update_id": uid_hex,
+            }
+            # The full payload is retained in update_payloads for the whole
+            # scheduled lifetime (read at promotion and again at activation), so
+            # surface it here too. Without this, clients can show the rule text of
+            # PENDING proposals but not of approved/scheduled ones, even though the
+            # node already holds it. Mirrors the pending serialization above.
+            payload_obj = chain_state._lifecycle_manager.update_payloads.get(uid)
+            if payload_obj is not None:
+                entry["rule_revisions"] = list(payload_obj.rule_revisions)
+                entry["activate_at_height"] = int(payload_obj.activate_at_height)
+                entry["host_contract_patch"] = payload_obj.host_contract_patch
+                entry["proposer_pubkey"] = payload_obj.proposer_pubkey
+            scheduled_updates.append(entry)
 
         for uid, voter_set in chain_state._lifecycle_manager.votes.items():
             uid_hex = _normalize_hexish(uid)


### PR DESCRIPTION
## Problem

`getgovernance` returns the full payload (`rule_revisions`, `host_contract_patch`, `proposer_pubkey`) for **pending** updates, but for **scheduled** updates it emits only `{activation_height, update_id}`.

The lifecycle manager keeps the full payload in `update_payloads` for the entire scheduled lifetime (it's read at promotion in `_check_approval_promotion` and again at activation in `process_height_transitions`), so the data is available — it just isn't serialized.

Effect on clients (e.g. the SpeciFi wallet's governance view): a proposal's rule text and proposer are visible while it's pending, then disappear the moment it's approved and scheduled, even though the node still holds them. Users see "Approved network change" with no detail.

Verified against the live testnet node: `getgovernance` scheduled entries contain exactly `activation_height` + `update_id`.

## Fix

Mirror the pending serialization for scheduled entries, reading from `update_payloads.get(uid)` when present (`commands/getgovernance.py`). When the payload isn't retained, the entry degrades gracefully to the existing two-field shape.

The added fields are purely additive (existing consumers ignore unknown keys).

## Test plan

- [ ] Submit a consensus rule update, get it approved/scheduled, call `getgovernance`, confirm the scheduled entry now includes `rule_revisions` / `proposer_pubkey` / `activate_at_height` / `host_contract_patch`.
- [ ] Confirm pending + archival serialization is unchanged.