### PR TITLE
Fix/getgovernance expose scheduled rule text

### DIFF
--- a/commands/getgovernance.py
+++ b/commands/getgovernance.py
@@ -80,12 +80,22 @@ def execute(raw_command: str, container):
         for activation_height, uid in chain_state._lifecycle_manager.scheduled_updates:
             uid_hex = _normalize_hexish(uid)
             lifecycle[uid_hex] = "approved-and-scheduled"
-            scheduled_updates.append(
-                {
-                    "activation_height": int(activation_height),
-                    "update_id": uid_hex,
-                }
-            )
+            entry = {
+                "activation_height": int(activation_height),
+                "update_id": uid_hex,
+            }
+            # The full payload is retained in update_payloads for the whole
+            # scheduled lifetime (read at promotion and again at activation), so
+            # surface it here too. Without this, clients can show the rule text of
+            # PENDING proposals but not of approved/scheduled ones, even though the
+            # node already holds it. Mirrors the pending serialization above.
+            payload_obj = chain_state._lifecycle_manager.update_payloads.get(uid)
+            if payload_obj is not None:
+                entry["rule_revisions"] = list(payload_obj.rule_revisions)
+                entry["activate_at_height"] = int(payload_obj.activate_at_height)
+                entry["host_contract_patch"] = payload_obj.host_contract_patch
+                entry["proposer_pubkey"] = payload_obj.proposer_pubkey
+            scheduled_updates.append(entry)
 
         for uid, voter_set in chain_state._lifecycle_manager.votes.items():
             uid_hex = _normalize_hexish(uid)

--- a/tests/test_proposals_rendering.py
+++ b/tests/test_proposals_rendering.py
@@ -137,3 +137,50 @@ def test_votes_only_counted_for_pending():
         assert v["update_id"] == update1.update_id_hex
         assert v["voter_pubkey"] in [VALIDATOR_1, VALIDATOR_2]
 
+
+def test_scheduled_updates_include_revisions_and_patch():
+    # An approved-and-scheduled update must surface the same full payload as a
+    # pending one (rule text / patch / proposer), not just {activation_height,
+    # update_id}. The payload stays in update_payloads for the whole scheduled
+    # lifetime, so clients can keep showing the rule text after approval.
+    container = MockContainer()
+
+    update = ConsensusRuleUpdate(
+        rule_revisions=["scheduled rule 1", "scheduled rule 2"],
+        activate_at_height=700,
+        host_contract_patch={"proof_scheme": "bls_header_sig"},
+        proposer_pubkey=VALIDATOR_2,
+    )
+    mgr = container.chain_state._lifecycle_manager
+    mgr.update_payloads[update.update_id] = update
+    mgr.scheduled_updates.append((700, update.update_id))
+
+    resp = json.loads(getgov_execute("getgovernance", container))["data"]
+
+    assert len(resp["scheduled_updates"]) == 1
+    su = resp["scheduled_updates"][0]
+
+    assert su["update_id"] == update.update_id_hex
+    assert su["activation_height"] == 700
+    assert su["rule_revisions"] == ["scheduled rule 1", "scheduled rule 2"]
+    assert su["activate_at_height"] == 700
+    assert su["host_contract_patch"] == {"proof_scheme": "bls_header_sig"}
+    assert su["proposer_pubkey"] == VALIDATOR_2
+    assert resp["lifecycle"][update.update_id_hex] == "approved-and-scheduled"
+
+
+def test_scheduled_update_without_retained_payload_degrades_gracefully():
+    # If the payload isn't retained in update_payloads, the entry must fall back
+    # to the legacy two-field shape rather than erroring.
+    container = MockContainer()
+
+    update = ConsensusRuleUpdate(["orphan scheduled"], 800)
+    mgr = container.chain_state._lifecycle_manager
+    mgr.scheduled_updates.append((800, update.update_id))  # no update_payloads entry
+
+    resp = json.loads(getgov_execute("getgovernance", container))["data"]
+
+    assert len(resp["scheduled_updates"]) == 1
+    su = resp["scheduled_updates"][0]
+    assert su == {"activation_height": 800, "update_id": update.update_id_hex}
+


### PR DESCRIPTION
Supersedes #17 (rebased onto current `main` + adds test coverage). Original fix by @Jme-Tau.

## Problem
`getgovernance` returns the full payload (`rule_revisions`, `host_contract_patch`, `proposer_pubkey`) for **pending** updates, but for **scheduled** updates it emits only `{activation_height, update_id}`. The lifecycle manager keeps the full payload in `update_payloads` for the entire scheduled lifetime, so the data is available — it just isn't serialized. Effect on clients (e.g. the wallet governance view): a proposal's rule text and proposer are visible while pending, then vanish once approved/scheduled.

## Fix
Mirror the pending serialization for scheduled entries, reading from `update_payloads.get(uid)` when present. When the payload isn't retained, degrades gracefully to the existing two-field shape. Purely additive.

## Test coverage
Adds two tests to `tests/test_proposals_rendering.py`:
- `test_scheduled_updates_include_revisions_and_patch` — asserts full payload; fails `KeyError: 'rule_revisions'` without the fix.
- `test_scheduled_update_without_retained_payload_degrades_gracefully` — fallback two-field shape.

Rebased onto current `main`. Governance suite green locally (35 passed).